### PR TITLE
Add hook for all visualizations that should be available in a RVV watch

### DIFF
--- a/packages/RuntimeValueVisualization-Tools.package/.squot-contents
+++ b/packages/RuntimeValueVisualization-Tools.package/.squot-contents
@@ -1,6 +1,5 @@
 SquotTrackedObjectMetadata {
 	#objectClassName : #PackageInfo,
-	#ignoredInstanceVariables : IdentityDictionary { },
 	#objectsReplacedByNames : true,
 	#serializer : #SquotCypressCodeSerializer
 }

--- a/packages/RuntimeValueVisualization-Tools.package/.squot-contents
+++ b/packages/RuntimeValueVisualization-Tools.package/.squot-contents
@@ -1,5 +1,6 @@
 SquotTrackedObjectMetadata {
 	#objectClassName : #PackageInfo,
+	#ignoredInstanceVariables : IdentityDictionary { },
 	#objectsReplacedByNames : true,
 	#serializer : #SquotCypressCodeSerializer
 }

--- a/packages/RuntimeValueVisualization-Tools.package/RVVWatch.class/instance/allVisualizations.st
+++ b/packages/RuntimeValueVisualization-Tools.package/RVVWatch.class/instance/allVisualizations.st
@@ -1,0 +1,4 @@
+accessing
+allVisualizations
+
+	^ RVVVisualization allSubclasses reject: [:ea | ea isAbstract]

--- a/packages/RuntimeValueVisualization-Tools.package/RVVWatch.class/instance/usableVisualizations.st
+++ b/packages/RuntimeValueVisualization-Tools.package/RVVWatch.class/instance/usableVisualizations.st
@@ -1,7 +1,6 @@
 accessing
 usableVisualizations
-	
-	^ self data size = 0 
-		ifTrue: [RVVVisualization allSubclasses]
-		ifFalse: [RVVVisualization allSubclasses select: [:class | class canHandle: self data first]]
 
+	^ self data size = 0
+		ifTrue: [self allVisualizations]
+		ifFalse: [self allVisualizations select: [:class | class canHandle: self data first]]

--- a/packages/RuntimeValueVisualization-Tools.package/RVVWatch.class/methodProperties.json
+++ b/packages/RuntimeValueVisualization-Tools.package/RVVWatch.class/methodProperties.json
@@ -4,6 +4,7 @@
 		"defaultCyclic" : "lp 8/4/2021 11:43",
 		"defaultLabeled" : "lp 8/4/2021 11:43" },
 	"instance" : {
+		"allVisualizations" : "ct 1/15/2022 17:41",
 		"contextLabel" : "lp 8/4/2021 11:32",
 		"cycleSize" : "lp 8/4/2021 11:32",
 		"cycleSize:" : "lp 8/4/2021 11:32",
@@ -24,6 +25,6 @@
 		"switchToVisualization:" : "lp 7/14/2021 17:40",
 		"testForAndRemoveOverflowData" : "lp 8/4/2021 11:33",
 		"update:with:" : "lp 8/4/2021 11:33",
-		"usableVisualizations" : "lp 8/4/2021 11:33",
+		"usableVisualizations" : "ct 1/5/2022 14:48",
 		"visualization" : "lp 8/4/2021 11:33",
 		"visualization:" : "lp 8/4/2021 11:33" } }


### PR DESCRIPTION
Plug-ins and extensions may easily override `#allVisualizations`.